### PR TITLE
Make optional dependencies optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var concat = require('concat-stream');
 var File = require('vinyl');
 var fs = require('vinyl-fs');
 var through = require('through2');
+var optional = require('optional');
 
 /**
  * Initialize Imagemin
@@ -114,9 +115,9 @@ Imagemin.prototype.read = function (src) {
  */
 
 module.exports = Imagemin;
-module.exports.gifsicle = require('imagemin-gifsicle');
-module.exports.jpegtran = require('imagemin-mozjpeg');
-module.exports.mozjpeg = require('imagemin-mozjpeg');
-module.exports.optipng = require('imagemin-optipng');
-module.exports.pngquant = require('imagemin-pngquant');
-module.exports.svgo = require('imagemin-svgo');
+module.exports.gifsicle = optional('imagemin-gifsicle');
+module.exports.jpegtran = optional('imagemin-mozjpeg');
+module.exports.mozjpeg = optional('imagemin-mozjpeg');
+module.exports.optipng = optional('imagemin-optipng');
+module.exports.pngquant = optional('imagemin-pngquant');
+module.exports.svgo = optional('imagemin-svgo');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "concat-stream": "^1.4.6",
     "get-stdin": "^3.0.0",
     "meow": "^1.0.0",
+    "optional": "^0.1.0",
     "stream-combiner": "^0.2.1",
     "through2": "^0.6.1",
     "vinyl": "^0.4.3",


### PR DESCRIPTION
Right now I must have all optional dependencies with me for `imagemin` to be parsed. Optional dependencies should be, well, _optional_.
