### PR TITLE
Npm set to latest stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "engines": {
     "node": ">=0.10.0",
-    "npm": ">=2.1.5"
+    "npm": ">=2.1.4"
   },
   "bin": {
     "imagemin": "cli.js"


### PR DESCRIPTION
Currently causing install issues if you dont have npm 2.1.5 installed which is still a pre-release version of npm.
