### PR TITLE
Rename `use` option to `plugins`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const fsP = pify(fs);
 
 const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
 	const dest = output ? path.resolve(output, input) : null;
-	const pipe = opts.use.length > 0 ? promisePipe(opts.use)(data, opts) : Promise.resolve(data);
+	const pipe = opts.plugins.length > 0 ? promisePipe(opts.plugins)(data) : Promise.resolve(data);
 
 	return pipe
 		.then(buf => {
@@ -44,7 +44,8 @@ module.exports = (input, output, opts) => {
 		output = null;
 	}
 
-	opts = Object.assign({use: []}, opts);
+	opts = Object.assign({plugins: []}, opts);
+	opts.plugins = opts.use || opts.plugins;
 
 	return globby(input).then(paths => Promise.all(paths.map(x => handleFile(x, output, opts))));
 };
@@ -54,7 +55,8 @@ module.exports.buffer = (input, opts) => {
 		return Promise.reject(new TypeError('Expected a buffer'));
 	}
 
-	opts = Object.assign({use: []}, opts);
+	opts = Object.assign({plugins: []}, opts);
+	opts.plugins = opts.use || opts.plugins;
 
-	return opts.use.length > 0 ? promisePipe(opts.use)(input, opts) : Promise.resolve(input);
+	return opts.plugins.length > 0 ? promisePipe(opts.plugins)(input) : Promise.resolve(input);
 };

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ const imageminMozjpeg = require('imagemin-mozjpeg');
 const imageminPngquant = require('imagemin-pngquant');
 
 imagemin(['images/*.{jpg,png}'], 'build/images', {
-	use: [
+	plugins: [
 		imageminMozjpeg({targa: true}),
 		imageminPngquant({quality: '65-80'})
 	]
@@ -49,7 +49,7 @@ Set the destination folder to where your files will be written. If no destinatio
 
 #### options
 
-##### use
+##### plugins
 
 Type: `array`
 
@@ -67,7 +67,7 @@ The buffer to optimize.
 
 #### options
 
-##### use
+##### plugins
 
 Type: `array`
 

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ const fsP = pify(fs);
 
 test('optimize a file', async t => {
 	const buf = await fsP.readFile(path.join(__dirname, 'fixture.jpg'));
-	const files = await m(['fixture.jpg'], {use: imageminJpegtran()});
+	const files = await m(['fixture.jpg'], {plugins: imageminJpegtran()});
 
 	t.is(files[0].path, null);
 	t.true(files[0].data.length < buf.length);
@@ -19,14 +19,14 @@ test('optimize a file', async t => {
 
 test('optimize a buffer', async t => {
 	const buf = await fsP.readFile(path.join(__dirname, 'fixture.jpg'));
-	const data = await m.buffer(buf, {use: imageminJpegtran()});
+	const data = await m.buffer(buf, {plugins: imageminJpegtran()});
 
 	t.true(data.length < buf.length);
 	t.true(isJpg(data));
 });
 
 test('output error on corrupt images', async t => {
-	t.throws(m(['fixture-corrupt.jpg'], {use: imageminJpegtran()}), /Corrupt JPEG data/);
+	t.throws(m(['fixture-corrupt.jpg'], {plugins: imageminJpegtran()}), /Corrupt JPEG data/);
 });
 
 test('throw on wrong input', async t => {


### PR DESCRIPTION
Still keeps compatibility with the `use` option so that it wont break for existing users.