### PR TITLE
Don't recommend mozjpeg in the readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,12 +14,12 @@ $ npm install --save imagemin
 
 ```js
 const imagemin = require('imagemin');
-const imageminMozjpeg = require('imagemin-mozjpeg');
+const imageminJpegtran = require('imagemin-jpegtran');
 const imageminPngquant = require('imagemin-pngquant');
 
 imagemin(['images/*.{jpg,png}'], 'build/images', {
 	plugins: [
-		imageminMozjpeg(),
+		imageminJpegtran(),
 		imageminPngquant({quality: '65-80'})
 	]
 }).then(files => {


### PR DESCRIPTION
Because mozjpeg has some issues on some OSs (related to https://github.com/sindresorhus/gulp-imagemin/issues/179)
