### PR TITLE
Included a cwd option to retain folder structure when minifying.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const replaceExt = require('replace-ext');
 const fsP = pify(fs);
 
 const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
-	const dest = output ? path.join(output, path.basename(input)) : null;
+	const inputSrc = opts.cwd ? path.dirname(input).replace(opts.cwd, '') + path.basename(input) : path.basename(input);
+	const dest = output ? path.join(output, inputSrc) : null;
 	const pipe = opts.plugins.length > 0 ? promisePipe(opts.plugins)(data) : Promise.resolve(data);
 
 	return pipe


### PR DESCRIPTION
**Current problem:**
Output destinations are not following source structure, it is flatten accordingly to the user's defined destination. 

**Solution applied:**
Added a cwd option to identify the correct working path, cwd value will represent the path we need to remove from the glob pattern determined by the user. 

The reformatted path will then be prepended by the destination. 

I've tried not to alter too much but to keep with the original flow of the process. 

**Todo:**
If pull request is approved, to add cwd option to README.

**Priority:**
Urgent

**Reason:**
As a web developer myself, I depend on useful tools like this to get by my daily development. I believe by adding this request, it can help improve development workflows better. 