### PR TITLE
Introduce input path to ret object

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const fsP = pify(fs);
 
 const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
 	const dest = output ? path.join(output, path.basename(input)) : null;
-	console.log(input);
 
 	if (opts.plugins && !Array.isArray(opts.plugins)) {
 		throw new TypeError('The plugins option should be an `Array`');

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const fsP = pify(fs);
 
 const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
 	const dest = output ? path.join(output, path.basename(input)) : null;
+	console.log(input);
 
 	if (opts.plugins && !Array.isArray(opts.plugins)) {
 		throw new TypeError('The plugins option should be an `Array`');
@@ -25,7 +26,8 @@ const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
 
 			const ret = {
 				data: buf,
-				path: (fileType(buf) && fileType(buf).ext === 'webp') ? replaceExt(dest, '.webp') : dest
+				path: (fileType(buf) && fileType(buf).ext === 'webp') ? replaceExt(dest, '.webp') : dest,
+				inputPath: input
 			};
 
 			if (!dest) {

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ imagemin(['images/*.{jpg,png}'], 'build/images', {
 
 ### imagemin(input, [output], [options])
 
-Returns `Promise<Object[]>` in the format `{data: Buffer, path: String}`.
+Returns `Promise<Object[]>` in the format `{data: Buffer, path: String, inputPath: String}`.
 
 #### input
 


### PR DESCRIPTION
I encountered a usecase where I needed to write the buffer to a file myself, but still wanted to have information about the input file, while at the same time not specifing an output path. By introducing the `inputPath`parameter to the `ret`object, that contains a reference to the input file, I was able to do get exactly what I wanted, without breaking old functionality.
Now I can for example write the buffer to a file, with the same filename as the original.