### PR TITLE
Added option to set input as string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
 				.then(() => fsP.writeFile(ret.path, ret.data))
 				.then(() => ret);
 		})
-		.catch(err => {
-			err.message = `Error in file: ${input}\n\n${err.message}`;
-			throw err;
+		.catch(error => {
+			error.message = `Error in file: ${input}\n\n${error.message}`;
+			throw error;
 		});
 });
 
@@ -48,11 +48,11 @@ module.exports = (input, output, opts) => {
 		output = null;
 	}
 
-	opts = Object.assign({ plugins: [] }, opts);
+	opts = Object.assign({plugins: []}, opts);
 	opts.plugins = opts.use || opts.plugins;
 
 	if (Array.isArray(input)) {
-		return globby(input, { onlyFiles: true }).then(paths => Promise.all(paths.map(x => handleFile(x, output, opts))));
+		return globby(input, {onlyFiles: true}).then(paths => Promise.all(paths.map(x => handleFile(x, output, opts))));
 	}
 
 	if (typeof input === 'string') {
@@ -67,7 +67,7 @@ module.exports.buffer = (input, opts) => {
 		return Promise.reject(new TypeError(`Expected a \`Buffer\`, got \`${typeof input}\``));
 	}
 
-	opts = Object.assign({ plugins: [] }, opts);
+	opts = Object.assign({plugins: []}, opts);
 	opts.plugins = opts.use || opts.plugins;
 
 	if (opts.plugins.length === 0) {

--- a/index.js
+++ b/index.js
@@ -43,19 +43,23 @@ const handleFile = (input, output, opts) => fsP.readFile(input).then(data => {
 });
 
 module.exports = (input, output, opts) => {
-	if (!Array.isArray(input)) {
-		return Promise.reject(new TypeError(`Expected an \`Array\`, got \`${typeof input}\``));
-	}
-
 	if (typeof output === 'object') {
 		opts = output;
 		output = null;
 	}
 
-	opts = Object.assign({plugins: []}, opts);
+	opts = Object.assign({ plugins: [] }, opts);
 	opts.plugins = opts.use || opts.plugins;
 
-	return globby(input, {onlyFiles: true}).then(paths => Promise.all(paths.map(x => handleFile(x, output, opts))));
+	if (Array.isArray(input)) {
+		return globby(input, { onlyFiles: true }).then(paths => Promise.all(paths.map(x => handleFile(x, output, opts))));
+	}
+
+	if (typeof input === 'string') {
+		return handleFile(input, output, opts);
+	}
+
+	return Promise.reject(new TypeError(`Expected an \`Array<string>\` or \`string\`, got \`${typeof input}\``));
 };
 
 module.exports.buffer = (input, opts) => {
@@ -63,7 +67,7 @@ module.exports.buffer = (input, opts) => {
 		return Promise.reject(new TypeError(`Expected a \`Buffer\`, got \`${typeof input}\``));
 	}
 
-	opts = Object.assign({plugins: []}, opts);
+	opts = Object.assign({ plugins: [] }, opts);
 	opts.plugins = opts.use || opts.plugins;
 
 	if (opts.plugins.length === 0) {

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ import m from '.';
 
 const fsP = pify(fs);
 
-test('optimize a file', async t => {
+test('optimize an array of files', async t => {
 	const buf = await fsP.readFile(path.join(__dirname, 'fixture.jpg'));
 	const files = await m(['fixture.jpg'], {
 		plugins: [imageminJpegtran()]
@@ -21,6 +21,17 @@ test('optimize a file', async t => {
 	t.is(files[0].path, null);
 	t.true(files[0].data.length < buf.length);
 	t.true(isJpg(files[0].data));
+});
+
+test('optimize a single file', async t => {
+	const buf = await fsP.readFile(path.join(__dirname, 'fixture.jpg'));
+	const file = await m('fixture.jpg', {
+		plugins: [imageminJpegtran()]
+	});
+
+	t.is(file.path, null);
+	t.true(file.data.length < buf.length);
+	t.true(isJpg(file.data));
 });
 
 test('optimize a buffer', async t => {
@@ -40,7 +51,7 @@ test('output error on corrupt images', async t => {
 });
 
 test('throw on wrong input', async t => {
-	await t.throws(m('foo'), /Expected an `Array`, got `string`/);
+	await t.throws(m({foo: 'baar'}), /Expected an `Array<string>` or `string`, got `object`/);
 	await t.throws(m.buffer('foo'), /Expected a `Buffer`, got `string`/);
 });
 


### PR DESCRIPTION
I need to pass only one file at time to the `input`.

Today, I'm using like this:

```js
imagemin([pathToFile], outputDir, {
    plugins: [plugin],
})
```

But in this way, `globby-js` is used to find the file and for some reason it does not work when the file has parentheses in the name. Example: `'/my/path/my-image-1140x500 (1).png'`

So the solution I found was to check the input type:
- if is an array: works as before.
- if is string: just call the `handleFile` directly.

