### PR TITLE
Force globby update to fix cwd undefined error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"file-type": "^10.7.0",
-		"globby": "^8.0.1",
+		"globby": "^9",
 		"make-dir": "^1.0.0",
 		"p-pipe": "^1.1.0",
 		"pify": "^4.0.1",


### PR DESCRIPTION
cf https://github.com/kevva/dir-glob/issues/14#issuecomment-453992171

What I did is specify in my `package.json` the version of globby, I'm even using the `9.0.0` so just upgrade to the last one seem better.