### PR TITLE
Fix README commented example of `path` attribute

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ const imageminPngquant = require('imagemin-pngquant');
 	});
 
 	console.log(files);
-	//=> [{data: <Buffer 89 50 4e …>, path: 'build/images/foo.jpg'}, …]
+	//=> [{data: <Buffer 89 50 4e …>, destinationPath: 'build/images/foo.jpg'}, …]
 })();
 ```
 


### PR DESCRIPTION
Since 7.0.0 renamed `path` to `destinationPath`, the comment's example object `path` attribute should get renamed, too.

Documentation-only change.