### PR TITLE
Fix #292 EMFILE Error, by using graceful-fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const {promisify} = require('util');
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 const fileType = require('file-type');
 const globby = require('globby');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"dependencies": {
 		"file-type": "^12.0.0",
 		"globby": "^10.0.0",
+		"graceful-fs": "^3.2.2",
 		"junk": "^3.1.0",
 		"make-dir": "^3.0.0",
 		"p-pipe": "^3.0.0",


### PR DESCRIPTION
This change should fix #292 by using graceful-fs (https://www.npmjs.com/package/graceful-fs) as a drop-in replacement for fs. It is stable, tiny, with no runtime dependencies.