### PR TITLE
Add `preserveDirectories` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",
-	  	"cpy": "^8.1.0",
 		"del": "^6.0.0",
 		"imagemin-jpegtran": "^7.0.0",
 		"imagemin-svgo": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",
+	  	"cpy": "^8.1.0",
 		"del": "^6.0.0",
 		"imagemin-jpegtran": "^7.0.0",
 		"imagemin-svgo": "^9.0.0",

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,12 @@ Type: `string`
 
 Set the destination folder to where your files will be written. If no destination is specified, no files will be written.
 
+##### preserveDirectories
+
+Type: `boolean`
+
+If enabled the directory structure from the input is preserved.
+
 ##### plugins
 
 Type: `Array`

--- a/readme.md
+++ b/readme.md
@@ -101,9 +101,27 @@ Set the destination folder to where your files will be written. If no destinatio
 
 ##### preserveDirectories
 
-Type: `boolean`
+Type: `boolean`\
+Default: `false`
 
-If enabled the directory structure from the input is preserved.
+Preserve the source directory structure in the output.
+
+##### basePath
+
+Type: `string`\
+Default: `''`
+
+Ignore certain directories in the output.
+
+```js
+await imagemin(['assets/images/**/*.jpg'], {
+	destination: 'dist',
+	basePath: 'assets/images',
+	preserveDirectories: true,
+});
+```
+- `assets/images/1.jpg` -> `dist/1.jpg`
+- `assets/images/nested/2.svg` -> `dist/nested/2.svg`
 
 ##### plugins
 

--- a/test.js
+++ b/test.js
@@ -176,7 +176,7 @@ test('glob option', async t => {
 	t.true(isJpg(files[0].data));
 });
 
-test('Preserve directory structure', async t => {
+test('preserve directory structure', async t => {
 	const temporary = tempy.directory();
 	const destinationTemporary = tempy.directory();
 	const buffer = await fsPromises.readFile(path.join(__dirname, 'fixture.jpg'));


### PR DESCRIPTION
Fixes #191

If the `preserveDirectories` is set the output will match the directory structure from the input files. 

Another possibility would be to introduce a breaking change and make this the default behaviour as that's what I would expect, but maybe i'm biased as I need this feature in a current project :smile: 

Given: `assets/images/1.jpg, assets/images/nested/2.svg, assets/images/nested/nested/3.webp`

It will detect that `assets/images` is the basePath and will not copy over these directories to the destination.

``` javascript
imagemin(['assets/images/**/*.{jpg,svg,webp}'], {
	plugins: [imageminJpegtran(), imageminWebp(), imageminSvgo()],
	destination: 'dest',
	preserveDirectories: true
});
```

Our output would be `dest/1.jpg, dest/nested/assets/2.svg, dest/nested/nested/3.webp`

cc/ #293 #262 #225 #213 #196 #192
