### PR TITLE
Fix Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const makeDir = require('make-dir');
 const pPipe = require('p-pipe');
 const replaceExt = require('replace-ext');
 const junk = require('junk');
+const convertToUnixPath = require('slash');
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -44,7 +45,8 @@ module.exports = async (input, {glob = true, ...options} = {}) => {
 		throw new TypeError(`Expected an \`Array\`, got \`${typeof input}\``);
 	}
 
-	const filePaths = glob ? await globby(input, {onlyFiles: true}) : input;
+	const unixFilePaths = input.map(path => convertToUnixPath(path));
+	const filePaths = glob ? await globby(unixFilePaths, {onlyFiles: true}) : input;
 
 	return Promise.all(
 		filePaths

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"junk": "^3.1.0",
 		"make-dir": "^3.0.0",
 		"p-pipe": "^3.0.0",
-		"replace-ext": "^1.0.0"
+		"replace-ext": "^1.0.0",
+		"slash": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -104,6 +104,26 @@ test('output at the specified location', async t => {
 	await del([temp, destinationTemp], {force: true});
 });
 
+test('output at the specified location when input paths contain Windows path delimiter', async t => {
+	const temp = tempy.directory();
+	const destinationTemp = tempy.directory();
+	const buffer = await readFile(path.join(__dirname, 'fixture.jpg'));
+
+	await makeDir(temp);
+	await writeFile(path.join(temp, 'fixture.jpg'), buffer);
+
+	const fileNameWithWindowsPathDelimiter = `${temp}\\*.jpg`;
+
+	const files = await imagemin([fileNameWithWindowsPathDelimiter], {
+		destination: destinationTemp,
+		plugins: [imageminJpegtran()]
+	});
+
+	t.true(fs.existsSync(files[0].destinationPath));
+
+	await del([temp, destinationTemp], {force: true});
+});
+
 test('set webp ext', async t => {
 	const temp = tempy.file();
 	const files = await imagemin(['fixture.jpg'], {


### PR DESCRIPTION
PR adds explicit conversion for input file paths to Unix format which uses forward slash.

`imagemin` relies on `globby` package to calculate all file paths, when glob option is enabled. That package expects paths to use forward slashes as a path delimiter. When Windows path delimiter was encountered in the file name, the file was ignored, which resulted in `imagemin` not processing those files.

I also added a test for Windows delimiter, to make sure `imagemin` works with them correctly further down the road, but the test seems to me not super accurate because the tested path (generated by `tempy`) on Unix will contain both Unix and Windows path delimiters.

If you have any idea how to test the issue more specifically, feel free to update!

Fixes #352