### PR TITLE
Fix node imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-import {Buffer} from 'node:buffer';
-import {promises as fsPromises} from 'node:fs';
-import {promisify} from 'node:util';
-import path from 'node:path';
+import {Buffer} from 'buffer';
+import {promises as fsPromises} from 'fs';
+import {promisify} from 'util';
+import path from 'path';
 import fs from 'graceful-fs';
 import FileType from 'file-type';
 import {globby} from 'globby';


### PR DESCRIPTION
Fix the node imports that are broken on newer versions of node

E.g. `Error: Cannot find module node:buffer`

Note: The version of globby also needs to be updated to the version after this pull request in order to fix the errors completely:
https://github.com/sindresorhus/globby/pull/196

Node version: 16.3.0

Fixes #395 