### PR TITLE
use for await loop instead of promise.all

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,18 +49,21 @@ export default async function imagemin(input, {glob = true, ...options} = {}) {
 	const unixFilePaths = input.map(path => convertToUnixPath(path));
 	const filePaths = glob ? await globby(unixFilePaths, {onlyFiles: true}) : input;
 
-	return Promise.all(
-		filePaths
-			.filter(filePath => junk.not(path.basename(filePath)))
-			.map(async filePath => {
-				try {
-					return await handleFile(filePath, options);
-				} catch (error) {
-					error.message = `Error occurred when handling file: ${input}\n\n${error.stack}`;
-					throw error;
-				}
-			}),
-	);
+	let res = [];
+
+	for (let file of filePaths)
+	{
+		if (!junk.not(path.basename(file)))
+			continue;
+		try {
+			res.push(await handleFile(file, options));
+		} catch (error) {
+			error.message = `Error occurred when handling file: ${input}\n\n${error.stack}`;
+			throw error;
+		}
+	}
+
+	return res;
 }
 
 imagemin.buffer = async (input, {plugins = []} = {}) => {


### PR DESCRIPTION
I use for await instead of Promise.all because Promise.all load all files to memory and make all promises work at the same time
and because of that behaviou "Error: stdout read ENOTCONN problem" Happen  when you load multiple files
and to fix that problem I came with this solution to run file promise one by one not all at same time