### PR TITLE
fix: error thrown from changeFileExtension when destination is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ const handleFile = async (sourcePath, {destination, plugins = []}) => {
 
 	const {ext} = await fileTypeFromBuffer(data) ?? {ext: path.extname(sourcePath)};
 	let destinationPath = destination ? path.join(destination, path.basename(sourcePath)) : undefined;
-	destinationPath = ext === 'webp' ? changeFileExtension(destinationPath, 'webp') : destinationPath;
+	destinationPath = ext === 'webp' && destinationPath
+		? changeFileExtension(destinationPath, 'webp')
+		: destinationPath;
 
 	const returnValue = {
 		data: new Uint8Array(data),


### PR DESCRIPTION
When `destination` is undefined or empty string, instead of:

> If no destination is specified, no files will be written

`imagemin` throws error like below:

```
node:internal/process/promises:391
    triggerUncaughtException(err, true /* fromPromise */);
    ^

TypeError: Expected `filePath` to be a string, got `undefined`.
    at changeFileExtension (file:///REDACTED/node_modules/.pnpm/change-file-extension@0.1.1/node_modules/change-file-extension/index.js:5:9)
    at handleFile (file:///REDACTED/node_modules/.pnpm/imagemin@9.0.0/node_modules/imagemin/index.js:21:37)
    at async file:///REDACTED/node_modules/.pnpm/imagemin@9.0.0/node_modules/imagemin/index.js:54:13
```

Suspect commmit: https://github.com/imagemin/imagemin/commit/0f2a0aa91084017501b638e55f1af827be9601c6#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R6 

This is because `change-file-extension` will throw error when `filePath` is undefined, unlike `replace-ext` which will just return without error thrown.

Fix here is to call `change-file-extension` when `destination` is truthy